### PR TITLE
feat: make generate functions available on workers and any platform

### DIFF
--- a/src/robotstxt/index.ts
+++ b/src/robotstxt/index.ts
@@ -20,11 +20,13 @@ export async function generateRobotsTxt(
     ? [...defaultPolicies, ...policies]
     : policies;
   const robotText = await getRobotsText(policiesToUse);
+  const bytes = new TextEncoder().encode(robotText).byteLength;
+  
   return new Response(robotText, {
     headers: {
       ...headers,
       "Content-Type": "text/plain",
-      "Content-Length": String(Buffer.byteLength(robotText)),
+      "Content-Length": String(bytes),
     },
   });
 }

--- a/src/sitemap/index.ts
+++ b/src/sitemap/index.ts
@@ -11,11 +11,13 @@ export async function generateSitemap(
   const sitemap = await getSitemapXml(request, remixEntryContent, {
     siteUrl,
   });
+  const bytes = new TextEncoder().encode(sitemap).byteLength
+  
   return new Response(sitemap, {
     headers: {
       ...headers,
       "Content-Type": "application/xml",
-      "Content-Length": String(Buffer.byteLength(sitemap)),
+      "Content-Length": String(bytes),
     },
   });
 }


### PR DESCRIPTION
This PR introduces a better way to get the `Content-Length` from the resources, since `Buffer` is not present on workers I have search an alternative that can work in any platform