### PR TITLE
Replace lodash dependency with lodash.isequal.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@balavishnuvj/remix-seo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balavishnuvj/remix-seo",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash.isequal": "^4.5.0"
       },
       "devDependencies": {
-        "@types/lodash": "^4.14.178",
+        "@types/lodash.isequal": "^4.5.6",
         "@types/node": "^17.0.13",
         "typescript": "^4.5.5"
       },
@@ -76,6 +76,15 @@
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
       "dev": true
     },
+    "node_modules/@types/lodash.isequal": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz",
+      "integrity": "sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "17.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
@@ -118,10 +127,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -287,6 +296,15 @@
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
       "dev": true
     },
+    "@types/lodash.isequal": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz",
+      "integrity": "sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/node": {
       "version": "17.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
@@ -320,10 +338,10 @@
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "peer": true
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/balavishnuvj/remix-seo#readme",
   "devDependencies": {
-    "@types/lodash": "^4.14.178",
+    "@types/lodash.isequal": "^4.5.6",
     "@types/node": "^17.0.13",
     "typescript": "^4.5.5"
   },
@@ -36,7 +36,7 @@
     "@remix-run/server-runtime": "^1.0.0"
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash.isequal": "^4.5.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/src/sitemap/utils.ts
+++ b/src/sitemap/utils.ts
@@ -1,7 +1,7 @@
 // This is adapted from https://github.com/kentcdodds/kentcdodds.com
 
 import { EntryContext } from "@remix-run/server-runtime";
-import { isEqual } from "lodash";
+import isEqual from "lodash.isequal";
 import { SEOHandle, SitemapEntry } from "../types";
 
 type Options = {


### PR DESCRIPTION
Using the lodash dependency brings in the entire lodash library, which is an issue for some serverless environments like Cloudflare Pages/Workers which require a quick start up time. This commit replaces the lodash library with the isEqual function that is being used.