### PR TITLE
Support either Remix ^1.0.0 or ^2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balavishnuvj/remix-seo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balavishnuvj/remix-seo",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -17,8 +17,8 @@
         "typescript": "^4.5.5"
       },
       "peerDependencies": {
-        "@remix-run/react": "^1.0.0",
-        "@remix-run/server-runtime": "^1.0.0"
+        "@remix-run/react": "^1.0.0 || ^2.0.0",
+        "@remix-run/server-runtime": "^1.0.0 || ^2.0.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@remix-run/react": "^1.0.0",
-    "@remix-run/server-runtime": "^1.0.0"
+    "@remix-run/react": "^1.0.0 || ^2.0.0",
+    "@remix-run/server-runtime": "^1.0.0 || ^2.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.21"


### PR DESCRIPTION
Remix 2.0.0 is coming out very soon --- prereleases are coming out. Allow the peer dependencies to be met by Remix v1 or v2.