### PR TITLE
Make remix-seo npm installable from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./build/index.js",
   "private": false,
   "scripts": {
-    "build": "tsc --project tsconfig.json",
+    "prepare": "tsc --project tsconfig.json",
     "start": "tsc -w --project tsconfig.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Rename the "build" script to "prepare" so that it is run when installing remix-seo with npm from GitHub.