### PR TITLE
Import minimal subset of lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@balavishnuvj/remix-seo",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balavishnuvj/remix-seo",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "lodash.isequal": "^4.5.0"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "@types/lodash.isequal": "^4.5.6",
+        "@types/lodash": "^4.14.178",
         "@types/node": "^17.0.13",
         "typescript": "^4.5.5"
       },
@@ -76,15 +76,6 @@
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
       "dev": true
     },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz",
-      "integrity": "sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "17.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
@@ -127,10 +118,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -296,15 +287,6 @@
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
       "dev": true
     },
-    "@types/lodash.isequal": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz",
-      "integrity": "sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/node": {
       "version": "17.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
@@ -338,10 +320,10 @@
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "peer": true
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/balavishnuvj/remix-seo#readme",
   "devDependencies": {
-    "@types/lodash.isequal": "^4.5.6",
+    "@types/lodash": "^4.14.178",
     "@types/node": "^17.0.13",
     "typescript": "^4.5.5"
   },
@@ -36,7 +36,7 @@
     "@remix-run/server-runtime": "^1.0.0 || ^2.0.0"
   },
   "dependencies": {
-    "lodash.isequal": "^4.5.0"
+    "lodash": "^4.17.21"
   },
   "types": "./build/index.d.ts"
 }

--- a/src/sitemap/utils.ts
+++ b/src/sitemap/utils.ts
@@ -1,7 +1,7 @@
 // This is adapted from https://github.com/kentcdodds/kentcdodds.com
 
 import { EntryContext } from "@remix-run/server-runtime";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { SEOHandle, SitemapEntry } from "../types";
 
 type Options = {

--- a/src/sitemap/utils.ts
+++ b/src/sitemap/utils.ts
@@ -1,7 +1,7 @@
 // This is adapted from https://github.com/kentcdodds/kentcdodds.com
 
 import { EntryContext } from "@remix-run/server-runtime";
-import isEqual from "lodash.isequal";
+import { isEqual } from "lodash";
 import { SEOHandle, SitemapEntry } from "../types";
 
 type Options = {


### PR DESCRIPTION
Fixes https://github.com/balavishnuvj/remix-seo/pull/9.

Depend upon the full lodash package but only import the modules for the functions that we use. This is the recommended way to use lodash to produce the smallest possible bundles for serverless deployment.

From the [Lodash documentation](https://lodash.com/per-method-packages):

> Lodash methods are available in standalone [per method packages](https://www.npmjs.com/browse/keyword/lodash-modularized) like lodash.mapvalues, lodash.pickby, etc. These packages contain only the code the method depends on.
> 
> **However, use of these packages is discouraged and they [will be removed in v5](https://github.com/lodash/lodash/issues/3838#issuecomment-398592530).**
> 
> Although they may seem more lightweight, they will usually increase the size of node_modules and webpack/rollup bundles in a project that transitively depends on multiple per method packages and/or the main lodash package. Whereas many methods in the main lodash package share code, the per method packages internally bundle copies of any code they depend on.
> 
> For example, throttle uses debounce internally. In a project using both methods from the main lodash package, throttle will import the same debounce module as any code that imports debounce directly, so only one copy of debounce will wind up in a webpack bundle.
> 
> On the other hand, if a project imports throttle from lodash.throttle, the extra copy of the debounce code internally bundled into lodash.throttle will wind up in the webpack bundle, in addition to debounce from the main lodash package or lodash.debounce.