### PR TITLE
Consume route manifest from server build instead of context

### DIFF
--- a/src/sitemap/index.ts
+++ b/src/sitemap/index.ts
@@ -1,16 +1,14 @@
-import { EntryContext } from "@remix-run/server-runtime";
+import type { ServerBuild } from "@remix-run/server-runtime";
 import { SEOOptions } from "../types";
 import { getSitemapXml } from "./utils";
 
 export async function generateSitemap(
   request: Request,
-  remixEntryContent: EntryContext,
+  routes: ServerBuild["routes"],
   options: SEOOptions
 ) {
   const { siteUrl, headers } = options;
-  const sitemap = await getSitemapXml(request, remixEntryContent, {
-    siteUrl,
-  });
+  const sitemap = await getSitemapXml(request, routes, { siteUrl });
   const bytes = new TextEncoder().encode(sitemap).byteLength
   
   return new Response(sitemap, {


### PR DESCRIPTION
Perhaps surprisingly, you can import the server build in any route module, like this:

```ts
import * as build from '@remix-run/dev/server-build'
import { useLoaderData } from '@remix-run/react'

export function loader() {
  return Object.keys(build.routes)
}

export default function () {
  const routes = useLoaderData<typeof loader>()
  return (
    <>
      <h1>List of routes</h1>
      <ul>
        {routes.map((route) => (
          <li key={route}>{route}</li>
        ))}
      </ul>
    </>
  )
}
```

As a result, customizing the Remix server entry point is not necessary.

See https://github.com/remix-run/remix/discussions/2912#discussioncomment-7013261